### PR TITLE
Fix makedist-based build errors

### DIFF
--- a/scripts/makedist
+++ b/scripts/makedist
@@ -51,7 +51,6 @@ execdir=`realpath $execdir`
 PACKAGE_DIR=`dirname $execdir`
 SOURCE_DIR=$PACKAGE_DIR/php
 DIST_DIR=$PACKAGE_DIR/dist
-BUILD_DIR=$SOURCE_DIR/dist
 VERSION=
 
 
@@ -113,7 +112,7 @@ while [ "$1" != "" ]; do
 done
 
 true ${DIST_DIR:=$PACKAGE_DIR/dist}
-BUILD_DIR=$SOURCE_DIR/dist
+BUILD_DIR=$SOURCE_DIR/build
 mkdir -p $BUILD_DIR $DIST_DIR
 
 
@@ -145,7 +144,7 @@ installdir=$BUILD_DIR/nextcloud-api
 set -x
 mkdir -p $installdir
 
-cp -r $PACKAGE_DIR/php/* $BUILD_DIR/*
+cp -r $PACKAGE_DIR/php/* $BUILD_DIR
 
 # ENTER COMMANDS for creating the dependency file(s)
 #

--- a/scripts/makedist.docker
+++ b/scripts/makedist.docker
@@ -20,7 +20,7 @@ execdir=`dirname $0`
 export CODEDIR=`(cd $execdir/.. > /dev/null 2>&1; pwd)`
 export DOCKERDIR=$CODEDIR/docker
 
-$DOCKERDIR/dockbuild.sh
+# $DOCKERDIR/dockbuild.sh
 # Run the main makedist in the dockerdir
 echo "Run makedist for nextcloud-api"
 exec $DOCKERDIR/makedist "$@"


### PR DESCRIPTION
This PR fixes syntax and copy errors in the `makedist` script that prevents it from building a distribution.  It also tweaks `makedist.docker` (eliminating a call to the non-existent `dockbuild.sh` script) so to prevent an error message from appearing in `localdeploy` output.  

To test, you should be able to checkout this branch and run `scripts/makedist` and `scripts/makedist.docker`; both will produce a zip file in the `dist` subdirectory.
