### PR TITLE
Upgrade/firebase jwt

### DIFF
--- a/php/composer.json
+++ b/php/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": "^8.3",
-        "firebase/php-jwt": "^6.0",
+        "firebase/php-jwt": "^7.0",
         "guzzlehttp/guzzle": "^7.0",
         "monolog/monolog": "^3.0"
     },

--- a/php/composer.json
+++ b/php/composer.json
@@ -1,7 +1,6 @@
 {
     "require": {
         "php": "^8.3",
-        "firebase/php-jwt": "^7.0",
         "guzzlehttp/guzzle": "^7.0",
         "monolog/monolog": "^3.0"
     },


### PR DESCRIPTION
Removed firebase php-jwt as it is legacy dependency used when the nextcloud API used JWT tokens as security layer inside the repo.